### PR TITLE
 Make the Stop button work in ProgressDlg 

### DIFF
--- a/DeepSkyStacker/ProgressDlg.h
+++ b/DeepSkyStacker/ProgressDlg.h
@@ -42,10 +42,6 @@ public:
 public :
 	void PeekAndPump()
 	{
-		// The Stop button (mostly) ignores mouse clicks if the focus is constantly stealed here.
-		//if (m_hWnd && ::GetFocus() != m_hWnd)
-		//	SetFocus();
-
 		MSG msg;
 		while (!m_bCancelled && ::PeekMessage(&msg, NULL,0,0,PM_NOREMOVE)) 
 		{


### PR DESCRIPTION
The ProgressDlg, which is displayed during registering or stacking, has a Stop button. However it usually ignored mouse clicks here. It is possible to use Space key to stop the process, but it would be nice to be able to click the Stop button with the mouse.  See also issue #36.

This change allows the Stop button in the ProgressDlg to react both on keyboard (Space, Enter keys) and mouse events.

It turned out that PeekAndPump method constantly re-sets focus, which apparently messed the mouse event processing. I've moved the focus setting code to CDSSProgressDlg::Start method to do it once when the progress dialog is setup initially.

Now it is possible to stop using either mouse or Space, Enter, Esc keys.

Thanks, Vitali