### PR TITLE
Cleaned up GetPixel/SetPixel methods to use parameter references wher…

### DIFF
--- a/DeepSkyStacker/BitmapExt.h
+++ b/DeepSkyStacker/BitmapExt.h
@@ -249,7 +249,7 @@ inline void ToRGB(double H, double S, double L, double & Red, double & Green, do
     }
 };
 
-inline double GetIntensity(COLORREF crColor)
+inline double GetIntensity(const COLORREF crColor)
 {
 	double	H, S, L;
 
@@ -258,7 +258,7 @@ inline double GetIntensity(COLORREF crColor)
 	return L;
 };
 
-inline double GetIntensity(COLORREF16 crColor)
+inline double GetIntensity(const COLORREF16 & crColor)
 {
 	double	H, S, L;
 
@@ -744,34 +744,19 @@ public :
 	virtual BOOL	GetScanLine(LONG j, void * pScanLine) = 0;
 	virtual BOOL	SetScanLine(LONG j, void * pScanLine) = 0;
 
-	virtual COLORREF GetPixel(LONG i, LONG j)
-	{
-		COLORREF	crResult;
-		double		fRed, fGreen, fBlue;
-
-		GetPixel(i, j, fRed, fGreen, fBlue);
-		crResult = RGB(fRed, fGreen, fBlue);
-
-		return crResult;
-	};
-
-	virtual COLORREF16 GetPixel16(LONG i, LONG j)
+	virtual BOOL	GetPixel16(LONG i, LONG j, COLORREF16 & crResult)
 	{
 		// Use get pixel
-		COLORREF16		crResult;
-		double			fRed, fGreen, fBlue;
-		
-
-		GetPixel(i, j, fRed, fGreen, fBlue);
+		double fRed, fGreen, fBlue;
+		BOOL fResult = GetPixel(i, j, fRed, fGreen, fBlue);
 
 		crResult.red = (WORD)(fRed * 256.0);
 		crResult.green = (WORD)(fGreen * 256.0);
 		crResult.blue = (WORD)(fBlue * 256.0);
-
-		return crResult;
+		return fResult;
 	};
 
-	virtual BOOL	SetPixel16(LONG i, LONG j, COLORREF16 crColor)
+	virtual BOOL	SetPixel16(LONG i, LONG j, const COLORREF16 & crColor)
 	{
 		return SetPixel(i, j, (double)crColor.red/256.0, (double)crColor.green/256.0, (double)crColor.blue/256.0);
 	};
@@ -1632,7 +1617,7 @@ private :
 		return TRUE;
 	};
 
-	TType	GetPrimary(LONG x, LONG y, COLORREF16 crColor)
+	TType	GetPrimary(LONG x, LONG y, const COLORREF16 & crColor)
 	{
 		switch (::GetBayerColor(x, y, m_CFAType))
 		{
@@ -2523,7 +2508,7 @@ public :
 		};
 	};
 
-	virtual BOOL	SetPixel16(LONG i, LONG j, COLORREF16 crColor16)
+	virtual BOOL	SetPixel16(LONG i, LONG j, const COLORREF16 &crColor16)
 	{
 		COLORREF			crColor;
 

--- a/DeepSkyStacker/EntropyInfo.cpp
+++ b/DeepSkyStacker/EntropyInfo.cpp
@@ -77,13 +77,12 @@ void CEntropyInfo::ComputeEntropies(LONG lMinX, LONG lMinY, LONG lMaxX, LONG lMa
 	vGreenHisto.resize((LONG)MAXWORD+1);
 	vBlueHisto.resize((LONG)MAXWORD+1);
 
+	COLORREF16		crColor;
 	for (i = lMinX;i<=lMaxX;i++)
 	{
 		for (j = lMinY;j<=lMaxY;j++)
 		{
-			COLORREF16		crColor;
-
-			crColor = m_pBitmap->GetPixel16(i, j);
+			m_pBitmap->GetPixel16(i, j, crColor);
 			vRedHisto[crColor.red]++;
 			vGreenHisto[crColor.green]++;
 			vBlueHisto[crColor.blue]++;
@@ -97,7 +96,8 @@ void CEntropyInfo::ComputeEntropies(LONG lMinX, LONG lMinY, LONG lMaxX, LONG lMa
 			double			qRed,
 							qBlue,
 							qGreen;
-			COLORREF16 &	crColor = m_pBitmap->GetPixel16(i, j);
+
+			m_pBitmap->GetPixel16(i, j, crColor);
 
 			qRed	= (double)vRedHisto[crColor.red]/(double)lNrPixels;
 			qGreen	= (double)vGreenHisto[crColor.green]/(double)lNrPixels;

--- a/DeepSkyStacker/EntropyInfo.h
+++ b/DeepSkyStacker/EntropyInfo.h
@@ -106,13 +106,12 @@ public :
 		InitSquareEntropies();
 	};
 
-	COLORREF16	GetPixel(LONG x, LONG y, double & fRedEntropy, double & fGreenEntropy, double & fBlueEntropy)
+	void	GetPixel(LONG x, LONG y, double & fRedEntropy, double & fGreenEntropy, double & fBlueEntropy, COLORREF16 & crResult)
 	{
-		COLORREF16		crResult;
 		LONG			lSquareX,
 						lSquareY;
 
-		crResult = m_pBitmap->GetPixel16(x, y);
+		m_pBitmap->GetPixel16(x, y, crResult);
 
 		lSquareX = x / (m_lWindowSize * 2 + 1);
 		lSquareY = y / (m_lWindowSize * 2 + 1);
@@ -170,8 +169,6 @@ public :
 		fRedEntropy		/= fTotalWeight;
 		fGreenEntropy	/= fTotalWeight;
 		fBlueEntropy	/= fTotalWeight;
-
-		return crResult;
 	};
 };
 

--- a/DeepSkyStacker/RAWUtils.cpp
+++ b/DeepSkyStacker/RAWUtils.cpp
@@ -788,7 +788,7 @@ BOOL CRawDecod::LoadRawFile(CMemoryBitmap * pBitmap, CDSSProgress * pProgress, B
 					int row, col;
 					for (row = 0; row < S.raw_height - S.top_margin * 2; row++)
 					{
-						for (col = 0; col < fuji_width << !fuji_layout; col++)
+						for (col = 0; col < fuji_width << int(!fuji_layout); col++)
 						{
 							if (fuji_layout)
 							{

--- a/DeepSkyStacker/RegisterEngine.cpp
+++ b/DeepSkyStacker/RegisterEngine.cpp
@@ -1064,7 +1064,7 @@ BOOL	CComputeLuminanceTask::DoTask(HANDLE hEvent)
 				{
 					COLORREF16			crColor;
 
-					crColor = m_pBitmap->GetPixel16(i, j);
+					m_pBitmap->GetPixel16(i, j, crColor);
 					m_pGrayBitmap->SetPixel(i, j, GetIntensity(crColor));
 				};
 			};

--- a/DeepSkyStacker/StackingEngine.cpp
+++ b/DeepSkyStacker/StackingEngine.cpp
@@ -1804,9 +1804,9 @@ BOOL	CStackTask::DoTask(HANDLE hEvent)
 									fBlueEntropy = 1.0;
 
 					if (m_pLightTask->m_Method == MBP_ENTROPYAVERAGE)
-						crColor = m_EntropyWindow.GetPixel(i, j, fRedEntropy, fGreenEntropy, fBlueEntropy);
+						m_EntropyWindow.GetPixel(i, j, fRedEntropy, fGreenEntropy, fBlueEntropy, crColor);
 					else
-						crColor = m_pBitmap->GetPixel16(i, j);
+						m_pBitmap->GetPixel16(i, j, crColor);
 
 					Red		= crColor.red;
 					Green	= crColor.green;


### PR DESCRIPTION
…e possible

Minor optimization for methods which use COLORREF16 parameter to avoid unnecessary invocation of the copy constructor.

Input parameters now use a const reference.

Return values of GetPixel methods are replaced with a reference (note that other GetPixel methods in CMemoryBitmap already use references to return color components).

Also a warning has been fixed in RawUtils.cpp. Sorry for mixing this in one commit.