### PR TITLE
Vectored Exception Handler

### DIFF
--- a/DeepSkyStacker/DeepSkyStacker.cpp
+++ b/DeepSkyStacker/DeepSkyStacker.cpp
@@ -65,7 +65,7 @@ using namespace Gdiplus;
 #include "qwinhost.h"
 
 #include "DeepSkyStacker.h"
-#include "DeepStack.h"
+//#include "DeepStack.h"
 #include "picturelist.h"
 
 
@@ -74,15 +74,16 @@ using namespace Gdiplus;
 #include "ui_StackingDlg.h"
 #include "StackRecap.h"
 #include "SetUILanguage.h"
-#include "StackWalker.h"
+//#include "StackWalker.h"
 #include <ZExcept.h>
 #if !defined(_WINDOWS)
 #include <execinfo.h>
 #endif
+#include "ExceptionHandling.h"
 
-#if defined(_WINDOWS)
-#include "APIHook.h"
-#endif
+//#if defined(_WINDOWS)
+//#include "APIHook.h"
+//#endif
 
 #pragma comment(lib, "gdiplus.lib")
 #pragma comment(linker,"\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
@@ -96,18 +97,18 @@ bool	g_bShowRefStars = false;
 #include <string.h>
 #include <stdio.h>
 
-class DSSStackWalker : public StackWalker
-{
-public:
-	DSSStackWalker() : StackWalker() {}
-protected:
-	virtual void OnOutput(LPCSTR text)
-	{
-		fprintf(stderr, text);
-		ZTRACE_RUNTIME(text);
-		StackWalker::OnOutput(text);
-	};
-};
+//class DSSStackWalker : public StackWalker
+//{
+//public:
+//	DSSStackWalker() : StackWalker() {}
+//protected:
+//	virtual void OnOutput(LPCSTR text)
+//	{
+//		fprintf(stderr, text);
+//		ZTRACE_RUNTIME(text);
+//		StackWalker::OnOutput(text);
+//	};
+//};
 
 bool	hasExpired()
 {
@@ -549,182 +550,182 @@ using namespace std;
 QTranslator theQtTranslator;
 QTranslator theAppTranslator;
 
-char* backPocket{ nullptr };
-constexpr int backPocketSize{ 1024 * 1024 };
+std::unique_ptr<std::uint8_t[]> backPocket;
+constexpr size_t backPocketSize{ 1024 * 1024 };
 
 static char const* global_program_name;
 
-namespace
-{
-	void writeOutput(const char* text)
-	{
-		fputs(text, stderr);
-		ZTRACE_RUNTIME(text);
-	};
-
-#if defined(_WINDOWS)
-#define EXCEPTION_CASE(code) \
- case code: \
-  exceptionString = #code "\n"; \
-  break
-
-	DSSStackWalker sw;
-
-	LONG WINAPI windows_exception_handler(EXCEPTION_POINTERS* ExceptionInfo)
-	{
-		const char* exceptionString = NULL;
-
-		switch (ExceptionInfo->ExceptionRecord->ExceptionCode)
-		{
-		EXCEPTION_CASE(EXCEPTION_ACCESS_VIOLATION);
-		EXCEPTION_CASE(EXCEPTION_ARRAY_BOUNDS_EXCEEDED);
-		EXCEPTION_CASE(EXCEPTION_BREAKPOINT);
-		EXCEPTION_CASE(EXCEPTION_DATATYPE_MISALIGNMENT);
-		EXCEPTION_CASE(EXCEPTION_FLT_DENORMAL_OPERAND);
-		EXCEPTION_CASE(EXCEPTION_FLT_DIVIDE_BY_ZERO);
-		EXCEPTION_CASE(EXCEPTION_FLT_INEXACT_RESULT);
-		EXCEPTION_CASE(EXCEPTION_FLT_INVALID_OPERATION);
-		EXCEPTION_CASE(EXCEPTION_FLT_OVERFLOW);
-		EXCEPTION_CASE(EXCEPTION_FLT_STACK_CHECK);
-		EXCEPTION_CASE(EXCEPTION_FLT_UNDERFLOW);
-		EXCEPTION_CASE(EXCEPTION_ILLEGAL_INSTRUCTION);
-		EXCEPTION_CASE(EXCEPTION_IN_PAGE_ERROR);
-		EXCEPTION_CASE(EXCEPTION_INT_DIVIDE_BY_ZERO);
-		EXCEPTION_CASE(EXCEPTION_INT_OVERFLOW);
-		EXCEPTION_CASE(EXCEPTION_INVALID_DISPOSITION);
-		EXCEPTION_CASE(EXCEPTION_NONCONTINUABLE_EXCEPTION);
-		EXCEPTION_CASE(EXCEPTION_PRIV_INSTRUCTION);
-		EXCEPTION_CASE(EXCEPTION_SINGLE_STEP);
-		EXCEPTION_CASE(EXCEPTION_STACK_OVERFLOW);
-		case 0xE06D7363:
-			exceptionString = "Unhandled C++ Exception ...\n";
-			break;
-		default:
-			exceptionString = "Error: Unrecognized Exception\n";
-			break;
-		}
-		writeOutput(exceptionString);
-		fflush(stderr);
-		/* If this is a stack overflow then we can't walk the stack, so just show
-		  where the error happened */
-		if (EXCEPTION_STACK_OVERFLOW != ExceptionInfo->ExceptionRecord->ExceptionCode)
-		{
-			sw.ShowCallstack();
-		}
-		else
-		{
-			char buffer[128]{};
-			snprintf(buffer, sizeof(buffer), "Stack Overflow Exception address: %p\n", (void*)ExceptionInfo->ContextRecord->Rip);
-			writeOutput(buffer);
-		}
-		DeepSkyStacker::instance()->close();
-		return EXCEPTION_EXECUTE_HANDLER;
-	}
-
-	LONG WINAPI RedirectedSetUnhandledExceptionFilter(EXCEPTION_POINTERS* /*ExceptionInfo*/)
-	{
-		// When the CRT calls SetUnhandledExceptionFilter with NULL parameter
-		// our handler will not get removed.
-		return 0;
-	}
-#else
-	/* Resolve symbol name and source location given the path to the executable
-	   and an address */
-	int addr2line(char const* const program_name, void const* const addr)
-	{
-		char addr2line_cmd[512] { 0 };
-
-		/* have addr2line map the address to the relevant line in the code */
-	#ifdef __APPLE__
-	  /* apple does things differently... */
-		sprintf(addr2line_cmd, "atos -o %.256s %p", program_name, addr);
-	#else
-		sprintf(addr2line_cmd, "addr2line -f -p -e %.256s %p", program_name, addr);
-	#endif
-
-		/* This will print a nicely formatted string specifying the
-		   function and source line of the address */
-		FILE* in;
-		char buff[512];
-		// is this the check for command execution exited with not 0?
-		if (!(in = popen(addr2line_cmd, "r"))) {
-			// I want to return the exit code and error message too if any
-			return 1;
-		}
-		// this part echoes the output of the command that's executed
-		while (fgets(buff, sizeof(buff), in) != NULL)
-		{
-			writeOutput(buff);
-		}
-		return WEXITSTATUS(pclose(in));
-	}
-
-	constexpr size_t MAX_STACK_FRAMES{ 64 };
-	static void* stack_traces[MAX_STACK_FRAMES];
-	void posix_print_stack_trace()
-	{
-		int i, trace_size = 0;
-		char** messages = (char**)NULL;
-		char buffer[1024]{};	// buffer for error message
-
-
-		trace_size = backtrace(stack_traces, MAX_STACK_FRAMES);
-		messages = backtrace_symbols(stack_traces, trace_size);
-
-		/* skip the first couple stack frames (as they are this function and
-		   our handler) and also skip the last frame as it's (always?) junk. */
-		   // for (i = 3; i < (trace_size - 1); ++i)
-		   // we'll use this for now so you can see what's going on
-		for (i = 0; i < trace_size; ++i)
-		{
-			if (addr2line(global_program_name, stack_traces[i]) != 0)
-			{
-				snprintf(buffer, sizeof(buffer)/sizeof(char),
-					"  error determining line # for: %s\n", messages[i]);
-				writeOutput(buffer);
-			}
-
-		}
-		if (messages) { free(messages); }
-	}
-
-	void signalHandler(int signal)
-	{
-		if (backPocket)
-		{
-			free(backPocket);
-			backPocket = nullptr;
-		}
-
-		char name[8]{};
-		switch (signal)
-		{
-		case SIGINT:
-			strcpy(name, "SIGINT");
-			break;
-		case SIGILL:
-			strcpy(name, "SIGILL");
-			break;
-		case SIGFPE:
-			strcpy(name, "SIGFPE");
-			break;
-		case SIGSEGV:
-			strcpy(name, "SIGSEGV");
-			break;
-		case SIGTERM:
-			strcpy(name, "SIGTERM");
-			break;
-		default:
-			snprintf(name, sizeof(name)/sizeof(char), "%d", signal);
-		}
-
-		ZTRACE_RUNTIME("In signalHandler(%s)", name);
-
-		posix_print_stack_trace();
-		DeepSkyStacker::instance()->close();
-	}
-#endif
-}
+//namespace
+//{
+//	void writeOutput(const char* text)
+//	{
+//		fputs(text, stderr);
+//		ZTRACE_RUNTIME(text);
+//	};
+//
+//#if defined(_WINDOWS)
+//#define EXCEPTION_CASE(code) \
+// case code: \
+//  exceptionString = #code "\n"; \
+//  break
+//
+//	DSSStackWalker sw;
+//
+//	LONG WINAPI windows_exception_handler(EXCEPTION_POINTERS* ExceptionInfo)
+//	{
+//		const char* exceptionString = NULL;
+//
+//		switch (ExceptionInfo->ExceptionRecord->ExceptionCode)
+//		{
+//		EXCEPTION_CASE(EXCEPTION_ACCESS_VIOLATION);
+//		EXCEPTION_CASE(EXCEPTION_ARRAY_BOUNDS_EXCEEDED);
+//		EXCEPTION_CASE(EXCEPTION_BREAKPOINT);
+//		EXCEPTION_CASE(EXCEPTION_DATATYPE_MISALIGNMENT);
+//		EXCEPTION_CASE(EXCEPTION_FLT_DENORMAL_OPERAND);
+//		EXCEPTION_CASE(EXCEPTION_FLT_DIVIDE_BY_ZERO);
+//		EXCEPTION_CASE(EXCEPTION_FLT_INEXACT_RESULT);
+//		EXCEPTION_CASE(EXCEPTION_FLT_INVALID_OPERATION);
+//		EXCEPTION_CASE(EXCEPTION_FLT_OVERFLOW);
+//		EXCEPTION_CASE(EXCEPTION_FLT_STACK_CHECK);
+//		EXCEPTION_CASE(EXCEPTION_FLT_UNDERFLOW);
+//		EXCEPTION_CASE(EXCEPTION_ILLEGAL_INSTRUCTION);
+//		EXCEPTION_CASE(EXCEPTION_IN_PAGE_ERROR);
+//		EXCEPTION_CASE(EXCEPTION_INT_DIVIDE_BY_ZERO);
+//		EXCEPTION_CASE(EXCEPTION_INT_OVERFLOW);
+//		EXCEPTION_CASE(EXCEPTION_INVALID_DISPOSITION);
+//		EXCEPTION_CASE(EXCEPTION_NONCONTINUABLE_EXCEPTION);
+//		EXCEPTION_CASE(EXCEPTION_PRIV_INSTRUCTION);
+//		EXCEPTION_CASE(EXCEPTION_SINGLE_STEP);
+//		EXCEPTION_CASE(EXCEPTION_STACK_OVERFLOW);
+//		case 0xE06D7363:
+//			exceptionString = "Unhandled C++ Exception ...\n";
+//			break;
+//		default:
+//			exceptionString = "Error: Unrecognized Exception\n";
+//			break;
+//		}
+//		writeOutput(exceptionString);
+//		fflush(stderr);
+//		/* If this is a stack overflow then we can't walk the stack, so just show
+//		  where the error happened */
+//		if (EXCEPTION_STACK_OVERFLOW != ExceptionInfo->ExceptionRecord->ExceptionCode)
+//		{
+//			sw.ShowCallstack();
+//		}
+//		else
+//		{
+//			char buffer[128]{};
+//			snprintf(buffer, sizeof(buffer), "Stack Overflow Exception address: %p\n", (void*)ExceptionInfo->ContextRecord->Rip);
+//			writeOutput(buffer);
+//		}
+//		DeepSkyStacker::instance()->close();
+//		return EXCEPTION_EXECUTE_HANDLER;
+//	}
+//
+//	LONG WINAPI RedirectedSetUnhandledExceptionFilter(EXCEPTION_POINTERS* /*ExceptionInfo*/)
+//	{
+//		// When the CRT calls SetUnhandledExceptionFilter with NULL parameter
+//		// our handler will not get removed.
+//		return 0;
+//	}
+//#else
+//	/* Resolve symbol name and source location given the path to the executable
+//	   and an address */
+//	int addr2line(char const* const program_name, void const* const addr)
+//	{
+//		char addr2line_cmd[512] { 0 };
+//
+//		/* have addr2line map the address to the relevant line in the code */
+//	#ifdef __APPLE__
+//	  /* apple does things differently... */
+//		sprintf(addr2line_cmd, "atos -o %.256s %p", program_name, addr);
+//	#else
+//		sprintf(addr2line_cmd, "addr2line -f -p -e %.256s %p", program_name, addr);
+//	#endif
+//
+//		/* This will print a nicely formatted string specifying the
+//		   function and source line of the address */
+//		FILE* in;
+//		char buff[512];
+//		// is this the check for command execution exited with not 0?
+//		if (!(in = popen(addr2line_cmd, "r"))) {
+//			// I want to return the exit code and error message too if any
+//			return 1;
+//		}
+//		// this part echoes the output of the command that's executed
+//		while (fgets(buff, sizeof(buff), in) != NULL)
+//		{
+//			writeOutput(buff);
+//		}
+//		return WEXITSTATUS(pclose(in));
+//	}
+//
+//	constexpr size_t MAX_STACK_FRAMES{ 64 };
+//	static void* stack_traces[MAX_STACK_FRAMES];
+//	void posix_print_stack_trace()
+//	{
+//		int i, trace_size = 0;
+//		char** messages = (char**)NULL;
+//		char buffer[1024]{};	// buffer for error message
+//
+//
+//		trace_size = backtrace(stack_traces, MAX_STACK_FRAMES);
+//		messages = backtrace_symbols(stack_traces, trace_size);
+//
+//		/* skip the first couple stack frames (as they are this function and
+//		   our handler) and also skip the last frame as it's (always?) junk. */
+//		   // for (i = 3; i < (trace_size - 1); ++i)
+//		   // we'll use this for now so you can see what's going on
+//		for (i = 0; i < trace_size; ++i)
+//		{
+//			if (addr2line(global_program_name, stack_traces[i]) != 0)
+//			{
+//				snprintf(buffer, sizeof(buffer)/sizeof(char),
+//					"  error determining line # for: %s\n", messages[i]);
+//				writeOutput(buffer);
+//			}
+//
+//		}
+//		if (messages) { free(messages); }
+//	}
+//
+//	void signalHandler(int signal)
+//	{
+//		if (backPocket)
+//		{
+//			free(backPocket);
+//			backPocket = nullptr;
+//		}
+//
+//		char name[8]{};
+//		switch (signal)
+//		{
+//		case SIGINT:
+//			strcpy(name, "SIGINT");
+//			break;
+//		case SIGILL:
+//			strcpy(name, "SIGILL");
+//			break;
+//		case SIGFPE:
+//			strcpy(name, "SIGFPE");
+//			break;
+//		case SIGSEGV:
+//			strcpy(name, "SIGSEGV");
+//			break;
+//		case SIGTERM:
+//			strcpy(name, "SIGTERM");
+//			break;
+//		default:
+//			snprintf(name, sizeof(name)/sizeof(char), "%d", signal);
+//		}
+//
+//		ZTRACE_RUNTIME("In signalHandler(%s)", name);
+//
+//		posix_print_stack_trace();
+//		DeepSkyStacker::instance()->close();
+//	}
+//#endif
+//}
 int main(int argc, char* argv[])
 {
 	ZFUNCTRACE_RUNTIME();
@@ -738,8 +739,8 @@ int main(int argc, char* argv[])
 	// Create a storage cushion (aka back pocket storage)
 	// and ensure that it is actually touched.
 	//
-	backPocket = static_cast<char*>(malloc(backPocketSize));
-	for (auto p = backPocket; p < backPocket + backPocketSize; p += 4096)
+	backPocket = std::make_unique<std::uint8_t[]>(backPocketSize);
+	for (auto* p = backPocket.get(); p < backPocket.get() + backPocketSize; p += 4096)
 	{
 		*p = '\xff';
 	}
@@ -759,26 +760,29 @@ int main(int argc, char* argv[])
 	//
 	// Set things up to capture terminal errors
 	//
-#if defined(_WINDOWS)
-	::SetUnhandledExceptionFilter(windows_exception_handler);
+
+	setDssExceptionHandling();
+
+//#if defined(_WINDOWS)
+//	::SetUnhandledExceptionFilter(windows_exception_handler);
 
 	//
 	// Prevent anyone else from taking over our exception filter
 	//
-	CAPIHook apiHook("kernel32.dll",
-		"SetUnhandledExceptionFilter",
-		(PROC)RedirectedSetUnhandledExceptionFilter);
+//	CAPIHook apiHook("kernel32.dll",
+//		"SetUnhandledExceptionFilter",
+//		(PROC)RedirectedSetUnhandledExceptionFilter);
 
-#else
+//#else
 	//
 	// Set up to handle signals
 	//
-	std::signal(SIGINT, signalHandler);
-	std::signal(SIGILL, signalHandler);
-	std::signal(SIGFPE, signalHandler);
-	std::signal(SIGSEGV, signalHandler);
-	std::signal(SIGTERM, signalHandler);
-#endif
+//	std::signal(SIGINT, signalHandler);
+//	std::signal(SIGILL, signalHandler);
+//	std::signal(SIGFPE, signalHandler);
+//	std::signal(SIGSEGV, signalHandler);
+//	std::signal(SIGTERM, signalHandler);
+//#endif
 
 	if (hasExpired())
 		return FALSE;
@@ -894,11 +898,7 @@ int main(int argc, char* argv[])
 	}
 	catch (std::exception& e)
 	{
-		if (backPocket)
-		{
-			free(backPocket);
-			backPocket = nullptr;
-		}
+		backPocket.reset();
 		ZTRACE_RUNTIME("std::exception caught: %s", e.what());
 
 		QString errorMessage(e.what());
@@ -910,11 +910,7 @@ int main(int argc, char* argv[])
 	}
 	catch (CException& e)
 	{
-		if (backPocket)
-		{
-			free(backPocket);
-			backPocket = nullptr;
-		}
+		backPocket.reset();
 		constexpr unsigned int msglen{ 255 };
 		TCHAR message[msglen]{ 0x00 };
 		e.GetErrorMessage(&message[0], msglen);
@@ -925,11 +921,7 @@ int main(int argc, char* argv[])
 	}
 	catch (ZException& ze)
 	{
-		if (backPocket)
-		{
-			free(backPocket);
-			backPocket = nullptr;
-		}
+		backPocket.reset();
 
 		ZTRACE_RUNTIME("ZException %s thrown from: %s Function: %s() Line: %d\n\n%s",
 			ze.name(),
@@ -959,11 +951,7 @@ int main(int argc, char* argv[])
 	}
 	catch (...)
 	{
-		if (backPocket)
-		{
-			free(backPocket);
-			backPocket = nullptr;
-		}
+		backPocket.reset();
 
 		ZTRACE_RUNTIME("Unknown exception caught");
 
@@ -975,10 +963,7 @@ int main(int argc, char* argv[])
 #endif
 
 	}
-	if (backPocket)
-	{
-		free(backPocket); backPocket = nullptr;
-	}
+	backPocket.reset();
 	theApp.ExitInstance();
 	return result;
 }

--- a/DeepSkyStacker/DeepSkyStacker.cpp
+++ b/DeepSkyStacker/DeepSkyStacker.cpp
@@ -624,8 +624,7 @@ static char const* global_program_name;
 //
 //	LONG WINAPI RedirectedSetUnhandledExceptionFilter(EXCEPTION_POINTERS* /*ExceptionInfo*/)
 //	{
-//		// When the CRT calls SetUnhandledExceptionFilter with NULL parameter
-//		// our handler will not get removed.
+//		// When the CRT calls SetUnhandledExceptionFilter with NULL parameter, our handler will not get removed.
 //		return 0;
 //	}
 //#else
@@ -726,6 +725,7 @@ static char const* global_program_name;
 //	}
 //#endif
 //}
+
 int main(int argc, char* argv[])
 {
 	ZFUNCTRACE_RUNTIME();
@@ -760,7 +760,6 @@ int main(int argc, char* argv[])
 	//
 	// Set things up to capture terminal errors
 	//
-
 	setDssExceptionHandling();
 
 //#if defined(_WINDOWS)
@@ -898,7 +897,6 @@ int main(int argc, char* argv[])
 	}
 	catch (std::exception& e)
 	{
-		backPocket.reset();
 		ZTRACE_RUNTIME("std::exception caught: %s", e.what());
 
 		QString errorMessage(e.what());
@@ -910,7 +908,6 @@ int main(int argc, char* argv[])
 	}
 	catch (CException& e)
 	{
-		backPocket.reset();
 		constexpr unsigned int msglen{ 255 };
 		TCHAR message[msglen]{ 0x00 };
 		e.GetErrorMessage(&message[0], msglen);
@@ -921,7 +918,6 @@ int main(int argc, char* argv[])
 	}
 	catch (ZException& ze)
 	{
-		backPocket.reset();
 
 		ZTRACE_RUNTIME("ZException %s thrown from: %s Function: %s() Line: %d\n\n%s",
 			ze.name(),
@@ -951,8 +947,6 @@ int main(int argc, char* argv[])
 	}
 	catch (...)
 	{
-		backPocket.reset();
-
 		ZTRACE_RUNTIME("Unknown exception caught");
 
 		QString errorMessage("Unknown exception caught");
@@ -963,7 +957,6 @@ int main(int argc, char* argv[])
 #endif
 
 	}
-	backPocket.reset();
 	theApp.ExitInstance();
 	return result;
 }

--- a/DeepSkyStacker/DeepSkyStacker.vcxproj
+++ b/DeepSkyStacker/DeepSkyStacker.vcxproj
@@ -312,6 +312,7 @@ $(QtToolsPath)\windeployqt --pdb $(TargetPath)</Command>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="ExceptionHandling.cpp" />
     <ClCompile Include="group.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
@@ -542,6 +543,7 @@ $(QtToolsPath)\windeployqt --pdb $(TargetPath)</Command>
     <ClInclude Include="DSSVersion.h" />
     <ClInclude Include="EntropyInfo.h" />
     <QtMoc Include="ExplorerBar.h" />
+    <ClInclude Include="ExceptionHandling.h" />
     <ClInclude Include="FileProperty.h" />
     <ClInclude Include="Filters.h" />
     <ClInclude Include="FITSUtil.h" />

--- a/DeepSkyStacker/DeepSkyStacker.vcxproj.filters
+++ b/DeepSkyStacker/DeepSkyStacker.vcxproj.filters
@@ -405,6 +405,9 @@
     <ClCompile Include="..\Tools\APIHook.cpp">
       <Filter>Tools</Filter>
     </ClCompile>
+    <ClCompile Include="ExceptionHandling.cpp">
+      <Filter>Tools</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="DeepSkyStacker.rc">
@@ -788,6 +791,9 @@
       <Filter>Tools</Filter>
     </ClInclude>
     <ClInclude Include="..\Tools\Toolhelp.h">
+      <Filter>Tools</Filter>
+    </ClInclude>
+    <ClInclude Include="ExceptionHandling.h">
       <Filter>Tools</Filter>
     </ClInclude>
   </ItemGroup>

--- a/DeepSkyStacker/ExceptionHandling.cpp
+++ b/DeepSkyStacker/ExceptionHandling.cpp
@@ -1,0 +1,188 @@
+#include "stdafx.h"
+
+#if defined(_WINDOWS)
+
+#include <errhandlingapi.h>
+#include <ZExcept.h>
+#include "StackWalker.h"
+#include "DeepSkyStacker.h"
+
+
+extern std::unique_ptr<std::uint8_t[]> backPocket;
+
+namespace {
+
+	class DSSStackWalker : public StackWalker
+	{
+	public:
+		DSSStackWalker() : StackWalker() {}
+	protected:
+		virtual void OnOutput(LPCSTR text) override
+		{
+			fprintf(stderr, text);
+			ZTRACE_RUNTIME(text);
+			StackWalker::OnOutput(text);
+		}
+	};
+
+	DSSStackWalker sw;
+
+	void writeOutput(const char* text)
+	{
+		fputs(text, stderr);
+		ZTRACE_RUNTIME(text);
+	}
+
+	long WINAPI DssVectoredExceptionHandler(EXCEPTION_POINTERS* pointers)
+	{
+		const EXCEPTION_RECORD* exc = pointers->ExceptionRecord;
+
+		auto traceAndterminate = [](const char* text, const bool stacktrace) -> long
+		{
+			backPocket.reset();
+			writeOutput(text);
+			if (stacktrace)
+				sw.ShowCallstack();
+			fflush(stderr);
+			DeepSkyStacker::instance()->close();
+			return EXCEPTION_CONTINUE_SEARCH;
+		};
+
+		// These are the exceptions we handle. Each of them is so disastrous that the app cannot continue.
+		//   In those cases (except STACK_OVERFLOW), we try to print the stack trace.
+		// All other exceptions are ignored by our handler.
+		switch (exc->ExceptionCode)
+		{
+		case EXCEPTION_ACCESS_VIOLATION: return traceAndterminate("Error: EXCEPTION_ACCESS_VIOLATION\n", true);
+		case EXCEPTION_ARRAY_BOUNDS_EXCEEDED: return traceAndterminate("Error: EXCEPTION_ARRAY_BOUNDS_EXCEEDED\n", true);
+		case EXCEPTION_DATATYPE_MISALIGNMENT: return traceAndterminate("Error: EXCEPTION_DATATYPE_MISALIGNMENT\n", true);
+		case EXCEPTION_FLT_INVALID_OPERATION: return traceAndterminate("Error: EXCEPTION_FLT_INVALID_OPERATION\n", true);
+		case EXCEPTION_FLT_STACK_CHECK: return traceAndterminate("Error: EXCEPTION_FLT_STACK_CHECK\n", true);
+		case EXCEPTION_ILLEGAL_INSTRUCTION: return traceAndterminate("Error: EXCEPTION_ILLEGAL_INSTRUCTION\n", true);
+		case EXCEPTION_IN_PAGE_ERROR: return traceAndterminate("Error: EXCEPTION_IN_PAGE_ERROR\n", true);
+		case EXCEPTION_INT_DIVIDE_BY_ZERO: return traceAndterminate("Error: EXCEPTION_INT_DIVIDE_BY_ZERO\n", true);
+		case EXCEPTION_NONCONTINUABLE_EXCEPTION: return traceAndterminate("Error: EXCEPTION_NONCONTINUABLE_EXCEPTION\n", true);
+		case EXCEPTION_PRIV_INSTRUCTION: return traceAndterminate("Error: EXCEPTION_PRIV_INSTRUCTION\n", true);
+		case EXCEPTION_STACK_OVERFLOW: return traceAndterminate("Error: EXCEPTION_STACK_OVERFLOW\n", false);
+		default: break;
+		}
+
+		// Ignore the exception and let the normal exception handling continue.
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+} // namespace
+
+void setDssExceptionHandling()
+{
+	// Add our own vectored exception handler to the front of the handler chain, so it gets called early (ideally first).
+	AddVectoredExceptionHandler(1, DssVectoredExceptionHandler);
+}
+
+#else
+
+/* Resolve symbol name and source location given the path to the executable
+   and an address */
+int addr2line(char const* const program_name, void const* const addr)
+{
+	char addr2line_cmd[512]{ 0 };
+
+	/* have addr2line map the address to the relevant line in the code */
+#ifdef __APPLE__
+  /* apple does things differently... */
+	sprintf(addr2line_cmd, "atos -o %.256s %p", program_name, addr);
+#else
+	sprintf(addr2line_cmd, "addr2line -f -p -e %.256s %p", program_name, addr);
+#endif
+
+	/* This will print a nicely formatted string specifying the
+	   function and source line of the address */
+	FILE* in;
+	char buff[512];
+	// is this the check for command execution exited with not 0?
+	if (!(in = popen(addr2line_cmd, "r"))) {
+		// I want to return the exit code and error message too if any
+		return 1;
+	}
+	// this part echoes the output of the command that's executed
+	while (fgets(buff, sizeof(buff), in) != NULL)
+	{
+		writeOutput(buff);
+	}
+	return WEXITSTATUS(pclose(in));
+}
+
+constexpr size_t MAX_STACK_FRAMES{ 64 };
+static void* stack_traces[MAX_STACK_FRAMES];
+void posix_print_stack_trace()
+{
+	int i, trace_size = 0;
+	char** messages = (char**)NULL;
+	char buffer[1024]{};	// buffer for error message
+
+
+	trace_size = backtrace(stack_traces, MAX_STACK_FRAMES);
+	messages = backtrace_symbols(stack_traces, trace_size);
+
+	/* skip the first couple stack frames (as they are this function and
+	   our handler) and also skip the last frame as it's (always?) junk. */
+	   // for (i = 3; i < (trace_size - 1); ++i)
+	   // we'll use this for now so you can see what's going on
+	for (i = 0; i < trace_size; ++i)
+	{
+		if (addr2line(global_program_name, stack_traces[i]) != 0)
+		{
+			snprintf(buffer, sizeof(buffer) / sizeof(char),
+				"  error determining line # for: %s\n", messages[i]);
+			writeOutput(buffer);
+		}
+
+	}
+	if (messages) { free(messages); }
+}
+
+void signalHandler(int signal)
+{
+	if (backPocket)
+	{
+		free(backPocket);
+		backPocket = nullptr;
+	}
+
+	char name[8]{};
+	switch (signal)
+	{
+	case SIGINT:
+		strcpy(name, "SIGINT");
+		break;
+	case SIGILL:
+		strcpy(name, "SIGILL");
+		break;
+	case SIGFPE:
+		strcpy(name, "SIGFPE");
+		break;
+	case SIGSEGV:
+		strcpy(name, "SIGSEGV");
+		break;
+	case SIGTERM:
+		strcpy(name, "SIGTERM");
+		break;
+	default:
+		snprintf(name, sizeof(name) / sizeof(char), "%d", signal);
+	}
+
+	ZTRACE_RUNTIME("In signalHandler(%s)", name);
+
+	posix_print_stack_trace();
+	DeepSkyStacker::instance()->close();
+}
+
+void setDssExceptionHandling()
+{
+	std::signal(SIGINT, signalHandler);
+	std::signal(SIGILL, signalHandler);
+	std::signal(SIGFPE, signalHandler);
+	std::signal(SIGSEGV, signalHandler);
+	std::signal(SIGTERM, signalHandler);
+}
+
+#endif

--- a/DeepSkyStacker/ExceptionHandling.h
+++ b/DeepSkyStacker/ExceptionHandling.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void setDssExceptionHandling();


### PR DESCRIPTION
Replaces the Windows SetUnhandledExceptionFilter with a Vectored Exception Handler.
The advantage is that this cannot be overwritten or prevented by other mechanisms. Our handler will be called as first thing before any other exception mechanisms like structured exception handling or try{}/catch().
We only handle a handful of disastrous events like access violations or so.