### PR TITLE
Ignore brightness factors for RAW-files

### DIFF
--- a/DeepSkyStacker/BitmapExt.cpp
+++ b/DeepSkyStacker/BitmapExt.cpp
@@ -339,7 +339,7 @@ bool LoadPicture(LPCTSTR szFileName, CAllDepthBitmap& AllDepthBitmap, ProgressBa
 	{
 		AllDepthBitmap.Clear();
 
-		if (FetchPicture(fs::path{ szFileName }, AllDepthBitmap.m_pBitmap, pProgress))
+		if (FetchPicture(fs::path{ szFileName }, AllDepthBitmap.m_pBitmap, false, pProgress))
 		{
 			std::shared_ptr<CMemoryBitmap> pBitmap = AllDepthBitmap.m_pBitmap;
 			C16BitGrayBitmap* pGrayBitmap = dynamic_cast<C16BitGrayBitmap*>(pBitmap.get());
@@ -1293,7 +1293,7 @@ bool GetPictureInfo(LPCTSTR szFileName, CBitmapInfo& BitmapInfo)
 
 /* ------------------------------------------------------------------- */
 
-bool FetchPicture(const fs::path filePath, std::shared_ptr<CMemoryBitmap>& rpBitmap, ProgressBase* const pProgress)
+bool FetchPicture(const fs::path filePath, std::shared_ptr<CMemoryBitmap>& rpBitmap, const bool ignoreBrightness, ProgressBase* const pProgress)
 {
 	ZFUNCTRACE_RUNTIME();
 	ZTRACE_RUNTIME("Processing file %s", filePath.generic_string().c_str());
@@ -1324,7 +1324,7 @@ bool FetchPicture(const fs::path filePath, std::shared_ptr<CMemoryBitmap>& rpBit
 		int loadResult = 0;
 
 		if (IsRAWPicture(szFileName, BitmapInfo))
-			bResult = LoadRAWPicture(szFileName, rpBitmap, pProgress);
+			bResult = LoadRAWPicture(szFileName, rpBitmap, ignoreBrightness, pProgress);
 		if (bResult)
 			break;		// All done - file has been loaded 
 			
@@ -1348,7 +1348,7 @@ bool FetchPicture(const fs::path filePath, std::shared_ptr<CMemoryBitmap>& rpBit
 		//
 		// It wasn't a TIFF file, so try to load a FITS file
 		//
-		loadResult = LoadFITSPicture(szFileName, BitmapInfo, rpBitmap, pProgress);
+		loadResult = LoadFITSPicture(szFileName, BitmapInfo, rpBitmap, ignoreBrightness, pProgress);
 		if (0 == loadResult)
 		{
 			bResult = true;

--- a/DeepSkyStacker/BitmapExt.h
+++ b/DeepSkyStacker/BitmapExt.h
@@ -765,7 +765,7 @@ bool	LoadPicture(LPCTSTR szFileName, CAllDepthBitmap & AllDepthBitmap, ProgressB
 bool	DebayerPicture(CMemoryBitmap* pInBitmap, std::shared_ptr<CMemoryBitmap>& rpOutBitmap, ProgressBase * pProgress);
 
 #endif // DSSFILEDECODING
-bool FetchPicture(const fs::path filePath, std::shared_ptr<CMemoryBitmap>& rpBitmap, ProgressBase* const pProgress);
+bool FetchPicture(const fs::path filePath, std::shared_ptr<CMemoryBitmap>& rpBitmap, const bool ignoreBrightness, ProgressBase* const pProgress);
 
 bool	GetPictureInfo(LPCTSTR szFileName, CBitmapInfo & BitmapInfo);
 

--- a/DeepSkyStacker/FITSUtil.cpp
+++ b/DeepSkyStacker/FITSUtil.cpp
@@ -809,11 +809,13 @@ class CFITSReadInMemoryBitmap : public CFITSReader
 private :
 	std::shared_ptr<CMemoryBitmap>& m_outBitmap;
 	std::shared_ptr<CMemoryBitmap> m_pBitmap;
+	bool ignoreBrightness;
 
 public :
-	CFITSReadInMemoryBitmap(LPCTSTR szFileName, std::shared_ptr<CMemoryBitmap>& rpBitmap, ProgressBase*	pProgress):
-		CFITSReader(szFileName, pProgress),
-		m_outBitmap{ rpBitmap }
+	CFITSReadInMemoryBitmap(LPCTSTR szFileName, std::shared_ptr<CMemoryBitmap>& rpBitmap, const bool ignoreBr, ProgressBase* pProgress) :
+		CFITSReader{ szFileName, pProgress },
+		m_outBitmap{ rpBitmap },
+		ignoreBrightness{ ignoreBr }
 	{}
 
 	virtual ~CFITSReadInMemoryBitmap() { Close(); };
@@ -943,11 +945,12 @@ bool CFITSReadInMemoryBitmap::OnOpen()
 					pCFABitmapInfo->UseAHD(true);
 
 				// Retrieve ratios
-				GetFITSRatio(m_fRedRatio, m_fGreenRatio, m_fBlueRatio);
+				if (!this->ignoreBrightness)
+					GetFITSRatio(m_fRedRatio, m_fGreenRatio, m_fBlueRatio);
 			}
 		}
 		else
-			m_fBrightnessRatio = GetFITSBrightnessRatio();
+			m_fBrightnessRatio = this->ignoreBrightness ? 1.0 : GetFITSBrightnessRatio();
 
 		m_pBitmap->SetMaster(false);
 		if (m_fExposureTime)
@@ -990,21 +993,21 @@ bool CFITSReadInMemoryBitmap::OnRead(int lX, int lY, double fRed, double fGreen,
 					switch (::GetBayerColor(lX, lY, m_CFAType, m_xBayerOffset, m_yBayerOffset))
 					{
 					case BAYER_BLUE:
-						fRed = min(maxValue, fRed * m_fBlueRatio);
+						fRed = std::min(maxValue, fRed * m_fBlueRatio);
 						break;
 					case BAYER_GREEN:
-						fRed = min(maxValue, fRed * m_fGreenRatio);
+						fRed = std::min(maxValue, fRed * m_fGreenRatio);
 						break;
 					case BAYER_RED:
-						fRed = min(maxValue, fRed * m_fRedRatio);
+						fRed = std::min(maxValue, fRed * m_fRedRatio);
 						break;
 					}
 				}
 				else
 				{
-					fRed = min(maxValue, fRed * m_fBrightnessRatio);
-					fGreen = min(maxValue, fGreen * m_fBrightnessRatio);
-					fBlue = min(maxValue, fBlue * m_fBrightnessRatio);
+					fRed = std::min(maxValue, fRed * m_fBrightnessRatio);
+					fGreen = std::min(maxValue, fGreen * m_fBrightnessRatio);
+					fBlue = std::min(maxValue, fBlue * m_fBrightnessRatio);
 				}
 				m_pBitmap->SetPixel(lX, lY, fRed);
 			}
@@ -1054,11 +1057,11 @@ bool CFITSReadInMemoryBitmap::OnClose()
 }
 
 
-bool ReadFITS(LPCTSTR szFileName, std::shared_ptr<CMemoryBitmap>& rpBitmap, ProgressBase *	pProgress)
+bool ReadFITS(LPCTSTR szFileName, std::shared_ptr<CMemoryBitmap>& rpBitmap, const bool ignoreBrightness, ProgressBase* pProgress)
 {
 	ZFUNCTRACE_RUNTIME();
-	CFITSReadInMemoryBitmap	fits(szFileName, rpBitmap, pProgress);
-	return fits.Open() && fits.Read();
+	CFITSReadInMemoryBitmap	fitsReader{ szFileName, rpBitmap, ignoreBrightness, pProgress };
+	return fitsReader.Open() && fitsReader.Read();
 }
 
 
@@ -1805,14 +1808,14 @@ bool IsFITSPicture(LPCTSTR szFileName, CBitmapInfo& BitmapInfo)
 };
 
 
-int	LoadFITSPicture(LPCTSTR szFileName, CBitmapInfo& BitmapInfo, std::shared_ptr<CMemoryBitmap>& rpBitmap, ProgressBase* pProgress)
+int	LoadFITSPicture(LPCTSTR szFileName, CBitmapInfo& BitmapInfo, std::shared_ptr<CMemoryBitmap>& rpBitmap, const bool ignoreBrightness, ProgressBase* pProgress)
 {
 	ZFUNCTRACE_RUNTIME();
 	int result = -1; // -1 means not a FITS file.
 
 	if (GetFITSInfo(szFileName, BitmapInfo) && BitmapInfo.CanLoad())
 	{
-		if (ReadFITS(szFileName, rpBitmap, pProgress))
+		if (ReadFITS(szFileName, rpBitmap, ignoreBrightness, pProgress))
 		{
 			if (BitmapInfo.IsCFA() && (IsSuperPixels() || IsRawBayer() || IsRawBilinear()))
 			{

--- a/DeepSkyStacker/FITSUtil.h
+++ b/DeepSkyStacker/FITSUtil.h
@@ -141,7 +141,7 @@ public:
 		m_fRedRatio{ 1.0 },
 		m_fBlueRatio{ 1.0 },
 		m_bDSI{ false },
-		m_fBrightnessRatio{ 0 }
+		m_fBrightnessRatio{ 0.0 }
 	{}
 
 	virtual ~CFITSReader()
@@ -215,14 +215,14 @@ public:
 
 CFATYPE GetFITSCFATYPE();
 bool GetFITSInfo(LPCTSTR szFileName, CBitmapInfo& BitmapInfo);
-bool ReadFITS(LPCTSTR szFileName, std::shared_ptr<CMemoryBitmap>& rpBitmap, ProgressBase*	pProgress);
+bool ReadFITS(LPCTSTR szFileName, std::shared_ptr<CMemoryBitmap>& rpBitmap, const bool ignoreBrightness, ProgressBase* pProgress);
 bool WriteFITS(LPCTSTR szFileName, CMemoryBitmap* pBitmap, ProgressBase* pProgress, FITSFORMAT FITSFormat, LPCTSTR szDescription,
 			   int lISOSpeed, int lGain, double fExposure);
 bool WriteFITS(LPCTSTR szFileName, CMemoryBitmap* pBitmap, ProgressBase* pProgress, FITSFORMAT FITSFormat, LPCTSTR szDescription);
 bool WriteFITS(LPCTSTR szFileName, CMemoryBitmap* pBitmap, ProgressBase* pProgress, LPCTSTR szDescriptionL, int lISOSpeed, int lGain, double fExposure);
 bool WriteFITS(LPCTSTR szFileName, CMemoryBitmap* pBitmap, ProgressBase* pProgress, LPCTSTR szDescription);
 bool IsFITSPicture(LPCTSTR szFileName, CBitmapInfo& BitmapInfo);
-int	LoadFITSPicture(LPCTSTR szFileName, CBitmapInfo& BitmapInfo, std::shared_ptr<CMemoryBitmap>& rpBitmap, ProgressBase* pProgress);
+int	LoadFITSPicture(LPCTSTR szFileName, CBitmapInfo& BitmapInfo, std::shared_ptr<CMemoryBitmap>& rpBitmap, const bool ignoreBrightness, ProgressBase* pProgress);
 void GetFITSExtension(LPCTSTR szFileName, CString& strExtension);
 void GetFITSExtension(fs::path path, CString& strExtension);
 

--- a/DeepSkyStacker/PostCalibration.cpp
+++ b/DeepSkyStacker/PostCalibration.cpp
@@ -384,7 +384,7 @@ void PostCalibration::on_testCosmetic_clicked()
 					dlg.Start2(strText, 0);
 
 					std::shared_ptr<CMemoryBitmap> pBitmap;
-					if (::FetchPicture(filePath, pBitmap, &dlg))
+					if (::FetchPicture(filePath, pBitmap, false, &dlg))
 					{
 						// Apply offset, dark and flat to lightframe
 						MasterFrames.ApplyAllMasters(pBitmap, nullptr, &dlg);

--- a/DeepSkyStacker/RAWUtils.cpp
+++ b/DeepSkyStacker/RAWUtils.cpp
@@ -305,7 +305,7 @@ namespace { // Only use in this .cpp file
 		};
 
 		bool IsRawFile() const;
-		bool LoadRawFile(CMemoryBitmap* pBitmap, ProgressBase* pProgress = nullptr);
+		bool LoadRawFile(CMemoryBitmap* pBitmap, const bool ignoreBrightness, ProgressBase* pProgress);
 
 		bool GetModel(CString& strModel)
 		{
@@ -475,7 +475,7 @@ namespace { // Only use in this .cpp file
 	/* ------------------------------------------------------------------- */
 
 
-	bool CRawDecod::LoadRawFile(CMemoryBitmap* pBitmap, ProgressBase* pProgress)
+	bool CRawDecod::LoadRawFile(CMemoryBitmap* pBitmap, const bool ignoreBrightness, ProgressBase* pProgress)
 	{
 		ZFUNCTRACE_RUNTIME();
 
@@ -504,22 +504,13 @@ namespace { // Only use in this .cpp file
 
 		// const int maxargs = 50;
 		Workspace workspace;
-		double fBrightness = 1.0;
-		double fRedScale = 1.0;
-		double fBlueScale = 1.0;
-		double fGreenScale = 1.0;
+		const double fGreenScale = ignoreBrightness ? 1.0 : workspace.value("RawDDP/Brightness").toDouble();
+		const double fRedScale = ignoreBrightness ? 1.0 : (fGreenScale * workspace.value("RawDDP/RedScale").toDouble());
+		const double fBlueScale = ignoreBrightness ? 1.0 : (fGreenScale * workspace.value("RawDDP/BlueScale").toDouble());
 
 		do	// Do once!
 		{
 			const int numberOfProcessors = CMultitask::GetNrProcessors();
-
-			fBrightness = workspace.value("RawDDP/Brightness").toDouble();
-			fRedScale = workspace.value("RawDDP/RedScale").toDouble();
-			fBlueScale = workspace.value("RawDDP/BlueScale").toDouble();
-
-			fGreenScale = fBrightness;
-			fRedScale *= fBrightness;
-			fBlueScale *= fBrightness;
 
 			//bSuperPixels = IsSuperPixels();
 			//bRawBayer    = IsRawBayer();
@@ -994,7 +985,7 @@ bool IsRAWPicture(LPCTSTR szFileName, CBitmapInfo& BitmapInfo)
 
 /* ------------------------------------------------------------------- */
 
-bool LoadRAWPicture(LPCTSTR szFileName, std::shared_ptr<CMemoryBitmap>& rpBitmap, ProgressBase* pProgress)
+bool LoadRAWPicture(LPCTSTR szFileName, std::shared_ptr<CMemoryBitmap>& rpBitmap, const bool ignoreBrightness, ProgressBase* pProgress)
 {
 	ZFUNCTRACE_RUNTIME();
 	bool bResult = false;
@@ -1016,7 +1007,7 @@ bool LoadRAWPicture(LPCTSTR szFileName, std::shared_ptr<CMemoryBitmap>& rpBitmap
             ZTRACE_RUNTIME("Creating 16 bit RGB memory bitmap %p (%s)", pBitmap.get(), szFileName);
         }
 
-        bResult = dcr.LoadRawFile(pBitmap.get(), pProgress);
+        bResult = dcr.LoadRawFile(pBitmap.get(), ignoreBrightness, pProgress);
 
         if (bResult)
         {

--- a/DeepSkyStacker/RAWUtils.h
+++ b/DeepSkyStacker/RAWUtils.h
@@ -12,7 +12,7 @@ void PopRAWSettings();
 
 bool IsRAWPicture(LPCTSTR szFileName, CString& strModel);
 bool IsRAWPicture(LPCTSTR szFileName, CBitmapInfo& BitmapInfo);
-bool LoadRAWPicture(LPCTSTR szFileName, std::shared_ptr<CMemoryBitmap>& rpBitmap, ProgressBase* pProgress);
+bool LoadRAWPicture(LPCTSTR szFileName, std::shared_ptr<CMemoryBitmap>& rpBitmap, const bool ignoreBrightness, ProgressBase* pProgress);
 
 #else
 inline bool	IsSuperPixels()		{ return false; };

--- a/DeepSkyStacker/RegisterEngine.cpp
+++ b/DeepSkyStacker/RegisterEngine.cpp
@@ -1221,7 +1221,7 @@ void CLightFrameInfo::RegisterPicture()
 			m_pProgress->Start2(strText, 0);
 
 		std::shared_ptr<CMemoryBitmap> pBitmap;
-		bLoaded = ::FetchPicture(filePath, pBitmap, m_pProgress);
+		bLoaded = ::FetchPicture(filePath, pBitmap, this->m_PictureType == PICTURETYPE_FLATFRAME, m_pProgress);
 
 		if (m_pProgress != nullptr)
 			m_pProgress->End2();
@@ -1413,7 +1413,7 @@ bool CRegisterEngine::RegisterLightFrames(CAllStackingTasks& tasks, bool bForce,
 				return std::make_tuple(std::shared_ptr<CMemoryBitmap>{}, false, std::unique_ptr<CLightFrameInfo>{}, std::unique_ptr<CBitmapInfo>{});
 
 			std::shared_ptr<CMemoryBitmap> pBitmap;
-			bool success = ::FetchPicture(lfInfo->filePath, pBitmap, pTaskProgress);
+			bool success = ::FetchPicture(lfInfo->filePath, pBitmap, lfInfo->m_PictureType == PICTURETYPE_FLATFRAME, pTaskProgress);
 			return std::make_tuple(std::move(pBitmap), success, std::move(lfInfo), std::move(bmpInfo));
 		};
 

--- a/DeepSkyStacker/RunningStackingEngine.cpp
+++ b/DeepSkyStacker/RunningStackingEngine.cpp
@@ -78,7 +78,7 @@ bool CRunningStackingEngine::AddImage(CLightFrameInfo& lfi, ProgressBase* pProgr
 
 	// First load the input bitmap
 	std::shared_ptr<CMemoryBitmap> pBitmap;
-	if (::LoadFrame(lfi.filePath,PICTURETYPE_LIGHTFRAME, pProgress, pBitmap))
+	if (::LoadFrame(lfi.filePath, PICTURETYPE_LIGHTFRAME, pProgress, pBitmap))
 	{
 		QString strText;
 		pBitmap->RemoveHotPixels(pProgress);

--- a/DeepSkyStacker/StackingTasks.cpp
+++ b/DeepSkyStacker/StackingTasks.cpp
@@ -94,7 +94,7 @@ bool LoadFrame(const fs::path filePath, PICTURETYPE PictureType, ProgressBase* p
 		if (bOverrideRAW)
 			PushRAWSettings(false, true); // Allways use Raw Bayer for dark, offset, and flat frames
 
-		bResult = ::FetchPicture(filePath, rpBitmap, pProgress);
+		bResult = ::FetchPicture(filePath, rpBitmap, PictureType == PICTURETYPE_FLATFRAME, pProgress);
 
 		if (bOverrideRAW)
 			PopRAWSettings();

--- a/DeepSkyStackerLive/LiveEngine.cpp
+++ b/DeepSkyStackerLive/LiveEngine.cpp
@@ -288,7 +288,7 @@ BOOL CLiveEngine::LoadFile(LPCTSTR szFileName)
 
 		Start2(QString::fromStdWString(strText.GetString()), 0);
 		CAllDepthBitmap				adb;
-		adb.SetDontUseAHD(TRUE);
+		adb.SetDontUseAHD(true);
 
 		bResult = LoadPicture(szFileName, adb, this);
 		End2();
@@ -302,7 +302,7 @@ BOOL CLiveEngine::LoadFile(LPCTSTR szFileName)
 
 			strText.Format(IDS_REGISTERINGNAME, (LPCTSTR)szFileName);
 			Start2(QString::fromStdWString(strText.GetString()), 0);
-			lfi.SetBitmap(szFileName, FALSE, FALSE);
+			lfi.SetBitmap(szFileName, false, false);
 			lfi.SetProgress(this);
 			lfi.RegisterPicture(adb.m_pBitmap.get());
 			lfi.SaveRegisteringInfo();


### PR DESCRIPTION
When reading flat-frames from RAW files or FITS files, ignore the brightness, red-scale, and blue-scale. Instead use 1.0 for those values.