### PR TITLE
refactoring runtime Qt connection (SIGNAL/SLOT macros) to compiletime…

### DIFF
--- a/DeepSkyStacker/DeepSkyStacker.cpp
+++ b/DeepSkyStacker/DeepSkyStacker.cpp
@@ -261,7 +261,7 @@ void DeepSkyStacker::createStatusBar()
 {
 	statusBarText->setAlignment(Qt::AlignHCenter);
 	statusBar()->addWidget(statusBarText, 1);
-	connect(stackingDlg, SIGNAL(statusMessage(const QString&)), this, SLOT(updateStatus(const QString&)));
+	connect(stackingDlg, &DSS::StackingDlg::statusMessage, this, &DeepSkyStacker::updateStatus);
 }
 
 void DeepSkyStacker::reportError(const QString& message, const QString& type, Severity severity, Method method, bool terminate)
@@ -318,20 +318,20 @@ void DeepSkyStacker::showEvent(QShowEvent* event)
 void DeepSkyStacker::connectSignalsToSlots()
 {
 	connect(helpShortCut, &QShortcut::activated, this, &DeepSkyStacker::help);
-	connect(explorerBar, SIGNAL(addImages(PICTURETYPE)), stackingDlg, SLOT(onAddImages(PICTURETYPE)));
+	connect(explorerBar, &ExplorerBar::addImages, stackingDlg, &DSS::StackingDlg::onAddImages);
 
-	connect(explorerBar, SIGNAL(loadList(const QPoint&)), stackingDlg, SLOT(loadList(const QPoint&)));
-	connect(explorerBar, SIGNAL(saveList()), stackingDlg, SLOT(saveList()));
-	connect(explorerBar, SIGNAL(clearList()), stackingDlg, SLOT(clearList()));
+	connect(explorerBar, &ExplorerBar::loadList, stackingDlg, static_cast<void(DSS::StackingDlg::*)(const QPoint&)>(&DSS::StackingDlg::loadList));
+	connect(explorerBar, &ExplorerBar::saveList, stackingDlg, static_cast<void(DSS::StackingDlg::*)()>(&DSS::StackingDlg::saveList));
+	connect(explorerBar, &ExplorerBar::clearList, stackingDlg, &DSS::StackingDlg::clearList);
 
-	connect(explorerBar, SIGNAL(checkAbove()), stackingDlg, SLOT(checkAbove()));
-	connect(explorerBar, SIGNAL(checkAll()), stackingDlg, SLOT(checkAll()));
-	connect(explorerBar, SIGNAL(unCheckAll()), stackingDlg, SLOT(unCheckAll()));
+	connect(explorerBar, &ExplorerBar::checkAbove, stackingDlg, &DSS::StackingDlg::checkAbove);
+	connect(explorerBar, &ExplorerBar::checkAll, stackingDlg, &DSS::StackingDlg::checkAll);
+	connect(explorerBar, &ExplorerBar::unCheckAll, stackingDlg, &DSS::StackingDlg::unCheckAll);
 
-	connect(explorerBar, SIGNAL(registerCheckedImages()), stackingDlg, SLOT(registerCheckedImages()));
-	connect(explorerBar, SIGNAL(computeOffsets()), stackingDlg, SLOT(computeOffsets()));
-	connect(explorerBar, SIGNAL(stackCheckedImages()), stackingDlg, SLOT(stackCheckedImages()));
-	connect(explorerBar, SIGNAL(batchStack()), stackingDlg, SLOT(batchStack()));
+	connect(explorerBar, &ExplorerBar::registerCheckedImages, stackingDlg, &DSS::StackingDlg::registerCheckedImages);
+	connect(explorerBar, &ExplorerBar::computeOffsets, stackingDlg, &DSS::StackingDlg::computeOffsets);
+	connect(explorerBar, &ExplorerBar::stackCheckedImages, stackingDlg, &DSS::StackingDlg::stackCheckedImages);
+	connect(explorerBar, &ExplorerBar::batchStack, stackingDlg, &DSS::StackingDlg::batchStack);
 }
 
 void DeepSkyStacker::onInitialise()

--- a/DeepSkyStacker/RawDDPSettings.cpp
+++ b/DeepSkyStacker/RawDDPSettings.cpp
@@ -291,12 +291,12 @@ RawDDPSettings::RawDDPSettings(QWidget *parent) :
 	//
 	scaleValidator = new QDoubleValidator(0.0, 5.0, 4, this);
 
-	connect(ui->brightness, SIGNAL(editingFinished()), this, SLOT(brightness_editingFinished()));
-	connect(ui->redScale, SIGNAL(editingFinished()), this, SLOT(redScale_editingFinished()));
-	connect(ui->blueScale, SIGNAL(editingFinished()), this, SLOT(blueScale_editingFinished()));
-	connect(ui->brightness_2, SIGNAL(editingFinished()), this, SLOT(brightness_2_editingFinished()));
-	connect(ui->redScale_2, SIGNAL(editingFinished()), this, SLOT(redScale_2_editingFinished()));
-	connect(ui->blueScale_2, SIGNAL(editingFinished()), this, SLOT(blueScale_2_editingFinished()));
+	connect(ui->brightness, &QLineEdit::editingFinished, this, &RawDDPSettings::brightness_editingFinished);
+	connect(ui->redScale, &QLineEdit::editingFinished, this, &RawDDPSettings::redScale_editingFinished);
+	connect(ui->blueScale, &QLineEdit::editingFinished, this, &RawDDPSettings::blueScale_editingFinished);
+	connect(ui->brightness_2, &QLineEdit::editingFinished, this, &RawDDPSettings::brightness_2_editingFinished);
+	connect(ui->redScale_2, &QLineEdit::editingFinished, this, &RawDDPSettings::redScale_2_editingFinished);
+	connect(ui->blueScale_2, &QLineEdit::editingFinished, this, &RawDDPSettings::blueScale_2_editingFinished);
 
 	//
 	// forceUnsigned is no longer used
@@ -433,7 +433,7 @@ void RawDDPSettings::onInitDialog()
 		}
 	}
 
-	connect(ui->DSLRs, SIGNAL(currentIndexChanged(int)), this, SLOT(DSLRs_currentIndexChanged(int)));
+	connect(ui->DSLRs, &QComboBox::currentIndexChanged, this, &RawDDPSettings::DSLRs_currentIndexChanged);
 
 	updateBayerPattern().updateControls();
 

--- a/DeepSkyStacker/SaveEditChanges.cpp
+++ b/DeepSkyStacker/SaveEditChanges.cpp
@@ -45,7 +45,7 @@ namespace DSS
 		QDialog(parent)
 	{
 		setupUi(this);
-		connect(buttonBox, SIGNAL(clicked(QAbstractButton *)), this, SLOT(buttonClicked(QAbstractButton*)));
+		connect(buttonBox, &QDialogButtonBox::clicked, this, &SaveEditChanges::buttonClicked);
 
 		switch (getSaveEditMode())
 		{

--- a/DeepSkyStacker/StackSettings.cpp
+++ b/DeepSkyStacker/StackSettings.cpp
@@ -66,7 +66,7 @@ StackSettings::StackSettings(QWidget *parent) :
 	//
 	// If the user selects a tab we want to know.
 	//
-	connect(ui->tabWidget, SIGNAL(currentChanged(int)), this, SLOT(tabChanged(int)));
+	connect(ui->tabWidget, &QTabWidget::currentChanged, this, & StackSettings::tabChanged);
 
 	Workspace workspace;
 	workspace.Push();

--- a/DeepSkyStacker/StackingDlg.cpp
+++ b/DeepSkyStacker/StackingDlg.cpp
@@ -507,23 +507,21 @@ namespace DSS
 
 		mruPath.readSettings();
 
-		connect(ui->fourCorners, SIGNAL(clicked(bool)), ui->picture, SLOT(on_fourCorners_clicked(bool)));
-		connect(&imageLoader, SIGNAL(imageLoaded()), this, SLOT(imageLoad()));
-		connect(&imageLoader, SIGNAL(imageLoadFailed()), this, SLOT(imageLoadFailed()));
-		connect(ui->gamma, SIGNAL(pegMove(int)), this, SLOT(gammaChanging(int)));
-		connect(ui->gamma, SIGNAL(pegMoved(int)), this, SLOT(gammaChanged(int)));
+		connect(ui->fourCorners, &QToolButton::clicked, ui->picture, &DSS::ImageView::on_fourCorners_clicked);
+		connect(&imageLoader, &ImageLoader::imageLoaded, this, &StackingDlg::imageLoad);
+		connect(&imageLoader, &ImageLoader::imageLoadFailed, this, &StackingDlg::imageLoadFailed);
+		connect(ui->gamma, &QLinearGradientCtrl::pegMove, this, &StackingDlg::gammaChanging);
+		connect(ui->gamma, &QLinearGradientCtrl::pegMoved, this, &StackingDlg::gammaChanged);
 		//
 		// If user changes tab need to switch groups and table model
 		//
-		connect(pictureList->tabBar, SIGNAL(currentChanged(int)), this, SLOT(tabBar_currentChanged(int)));
+		connect(pictureList->tabBar, &QTabBar::currentChanged, this, &StackingDlg::tabBar_currentChanged);
 
 		//
 		// Handle Menu requests for PictureList tableView and tabBar controls
 		//
-		connect(pictureList->tableView, SIGNAL(customContextMenuRequested(const QPoint&)),
-			this, SLOT(tableView_customContextMenuRequested(const QPoint&)));
-		connect(pictureList->tabBar, SIGNAL(customContextMenuRequested(const QPoint&)),
-			this, SLOT(tabBar_customContextMenuRequested(const QPoint&)));
+		connect(pictureList->tableView, &QTableView::customContextMenuRequested, this, &StackingDlg::tableView_customContextMenuRequested);
+		connect(pictureList->tabBar, &QTabBar::customContextMenuRequested, this, &StackingDlg::tabBar_customContextMenuRequested);
 
 		retrieveLatestVersionInfo();
 	}
@@ -1063,8 +1061,7 @@ namespace DSS
 		//
 		// If the model data changes let me know
 		//
-		connect(frameList.currentTableModel(), SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&, const QList<int>&)),
-			this, SLOT(tableViewModel_dataChanged(const QModelIndex&, const QModelIndex&, const QList<int>&)));
+		connect(frameList.currentTableModel(), &ImageListModel::dataChanged, this, &StackingDlg::tableViewModel_dataChanged);
 		
 		//
 		// Set up a QSortFilterProxyModel to allow sorting of the table view
@@ -1125,8 +1122,7 @@ namespace DSS
 		pictureList->tableView->installEventFilter(this);
 
 		QItemSelectionModel* qsm = pictureList->tableView->selectionModel();
-		connect(qsm, SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)),
-			this, SLOT(tableView_selectionChanged(const QItemSelection&, const QItemSelection&)));
+		connect(qsm, &QItemSelectionModel::selectionChanged, this, &StackingDlg::tableView_selectionChanged);
 
 		//
 		// Add the Grey Point stop to the gradient 
@@ -2752,8 +2748,7 @@ namespace DSS
 	{
 		frameList.setGroup(index);
 		auto model{ frameList.currentTableModel() };
-		connect(frameList.currentTableModel(), SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&, const QList<int>&)),
-			this, SLOT(tableViewModel_dataChanged(const QModelIndex&, const QModelIndex&, const QList<int>&)));
+		connect(frameList.currentTableModel(), &ImageListModel::dataChanged, this, &StackingDlg::tableViewModel_dataChanged);
 		proxyModel->setSourceModel(model);
 	}
 

--- a/DeepSkyStacker/StackingParameters.cpp
+++ b/DeepSkyStacker/StackingParameters.cpp
@@ -26,7 +26,7 @@ StackingParameters::StackingParameters(QWidget *parent, PICTURETYPE theType) :
 
     ui->setupUi(this);
 
-//	connect(ui->backgroundCalibration, SIGNAL(linkActivated(const QString &)), this, SLOT(on_backgroundCalibration_linkActivated(const QString &)));
+	//connect(ui->backgroundCalibration, &QPushButton::linkActivated, this, &StackingParameters::on_backgroundCalibration_linkActivated);
 	//
 	// Make all the "optional" controls invisible
 	// 
@@ -80,8 +80,7 @@ StackingParameters::StackingParameters(QWidget *parent, PICTURETYPE theType) :
 
 	createActions().createMenus();
 
-	connect(this, SIGNAL(methodChanged(MULTIBITMAPPROCESSMETHOD)),
-		this, SLOT(updateControls(MULTIBITMAPPROCESSMETHOD)));
+	connect(this, &StackingParameters::methodChanged, this, &StackingParameters::updateControls);
 }
 
 StackingParameters & StackingParameters::createActions()
@@ -105,7 +104,7 @@ StackingParameters & StackingParameters::createActions()
 		[=]() { ui->backgroundCalibration->setText(rgbbgCalString); });
 
 	bgCalOptions = new QAction(tr("Options...", "ID_CALIBRATIONMENU_OPTIONS"), this);
-	connect(bgCalOptions, SIGNAL(triggered()), this, SLOT(backgroundCalibrationOptions()));
+	connect(bgCalOptions, &QAction::triggered, this, &StackingParameters::backgroundCalibrationOptions);
 
 	return *this;
 }

--- a/DeepSkyStacker/editstars.cpp
+++ b/DeepSkyStacker/editstars.cpp
@@ -287,11 +287,11 @@ namespace DSS
 
 	void EditStars::starsButtonPressed()
 	{
-		connect(imageView, SIGNAL(Image_leaveEvent(QEvent*)), this, SLOT(leaveEvent(QEvent*)));
-		connect(imageView, SIGNAL(Image_mousePressEvent(QMouseEvent*)), this, SLOT(mousePressEvent(QMouseEvent*)));
-		connect(imageView, SIGNAL(Image_mouseMoveEvent(QMouseEvent*)), this, SLOT(mouseMoveEvent(QMouseEvent*)));
-		connect(imageView, SIGNAL(Image_mouseReleaseEvent(QMouseEvent*)), this, SLOT(mouseReleaseEvent(QMouseEvent*)));
-		connect(imageView, SIGNAL(Image_resizeEvent(QResizeEvent*)), this, SLOT(resizeMe(QResizeEvent*)));
+		connect(imageView, &ImageView::Image_leaveEvent, this, &EditStars::leaveEvent);
+		connect(imageView, &ImageView::Image_mousePressEvent, this, & EditStars::mousePressEvent);
+		connect(imageView, &ImageView::Image_mouseMoveEvent, this, & EditStars::mouseMoveEvent);
+		connect(imageView, &ImageView::Image_mouseReleaseEvent, this, & EditStars::mouseReleaseEvent);
+		connect(imageView, &ImageView::Image_resizeEvent, this, & EditStars::resizeMe);
 		m_bCometMode = false;
 		show();
 		raise();
@@ -300,11 +300,11 @@ namespace DSS
 
 	void EditStars::cometButtonPressed()
 	{
-		connect(imageView, SIGNAL(Image_leaveEvent(QEvent*)), this, SLOT(leaveEvent(QEvent*)));
-		connect(imageView, SIGNAL(Image_mousePressEvent(QMouseEvent*)), this, SLOT(mousePressEvent(QMouseEvent*)));
-		connect(imageView, SIGNAL(Image_mouseMoveEvent(QMouseEvent*)), this, SLOT(mouseMoveEvent(QMouseEvent*)));
-		connect(imageView, SIGNAL(Image_mouseReleaseEvent(QMouseEvent*)), this, SLOT(mouseReleaseEvent(QMouseEvent*)));
-		connect(imageView, SIGNAL(Image_resizeEvent(QResizeEvent*)), this, SLOT(resizeMe(QResizeEvent*)));
+		connect(imageView, &ImageView::Image_leaveEvent, this, &EditStars::leaveEvent);
+		connect(imageView, &ImageView::Image_mousePressEvent, this, &EditStars::mousePressEvent);
+		connect(imageView, &ImageView::Image_mouseMoveEvent, this, &EditStars::mouseMoveEvent);
+		connect(imageView, &ImageView::Image_mouseReleaseEvent, this, &EditStars::mouseReleaseEvent);
+		connect(imageView, &ImageView::Image_resizeEvent, this, &EditStars::resizeMe);
 		m_bCometMode = true;
 		show();
 		raise();

--- a/DeepSkyStacker/selectrect.cpp
+++ b/DeepSkyStacker/selectrect.cpp
@@ -68,8 +68,7 @@ namespace DSS
         setAttribute(Qt::WA_WState_ExplicitShowHide);
  
         StackingDlg& stackingDlg{ DeepSkyStacker::instance()->getStackingDlg() };
-        connect(this, SIGNAL(selectRectChanged(QRectF)),
-            &stackingDlg, SLOT(setSelectionRect(QRectF)));
+        connect(this, &SelectRect::selectRectChanged, &stackingDlg, &StackingDlg::setSelectionRect);
     }
 
     /*!
@@ -296,10 +295,10 @@ namespace DSS
 
     void SelectRect::rectButtonPressed()
     {
-        connect(imageView, SIGNAL(Image_mousePressEvent(QMouseEvent*)), this, SLOT(mousePressEvent(QMouseEvent*)));
-        connect(imageView, SIGNAL(Image_mouseMoveEvent(QMouseEvent*)), this, SLOT(mouseMoveEvent(QMouseEvent*)));
-        connect(imageView, SIGNAL(Image_mouseReleaseEvent(QMouseEvent*)), this, SLOT(mouseReleaseEvent(QMouseEvent*)));
-        connect(imageView, SIGNAL(Image_resizeEvent(QResizeEvent*)), this, SLOT(resizeMe(QResizeEvent*)));
+        connect(imageView, &ImageView::Image_mousePressEvent, this, &SelectRect::mousePressEvent);
+        connect(imageView, &ImageView::Image_mouseMoveEvent, this, &SelectRect::mouseMoveEvent);
+        connect(imageView, &ImageView::Image_mouseReleaseEvent, this, &SelectRect::mouseReleaseEvent);
+        connect(imageView, &ImageView::Image_resizeEvent, this, &SelectRect::resizeMe);
         show();
         raise();
         activateWindow();

--- a/DeepSkyStackerCL/DeepSkyStackerCL.cpp
+++ b/DeepSkyStackerCL/DeepSkyStackerCL.cpp
@@ -74,7 +74,7 @@ bool DeepSkyStackerCommandLine::Run()
 	}
 
 	StackingTask* task = new StackingTask(this, Process, GetStackingParams(), ConsoleOut());
-	connect(task, SIGNAL(finished()), this, SLOT(quit()));
+	connect(task, &StackingTask::finished, this, &DeepSkyStackerCommandLine::quit);
 	QTimer::singleShot(0, task, SLOT(run()));
 	exec();
 

--- a/DeepSkyStackerLive/imageviewer.cpp
+++ b/DeepSkyStackerLive/imageviewer.cpp
@@ -66,15 +66,11 @@ namespace DSS
 
 	void ImageViewer::connectSignalsToSlots()
 	{
-		connect(fourCorners, SIGNAL(clicked(bool)), picture, SLOT(on_fourCorners_clicked(bool)));
-		connect(gamma, SIGNAL(pegMove(int)), this, SLOT(gammaChanging(int)));
-		connect(gamma, SIGNAL(pegMoved(int)), this, SLOT(gammaChanged(int)));
-		connect(information, &QLabel::linkActivated,
-			this, &ImageViewer::saveClicked);
-		connect(copyToClipboard, &QLabel::linkActivated,
-			this, &ImageViewer::copyStackedImage);
-
-
+		connect(fourCorners, &QToolButton::clicked, picture, &DSS::ImageView::on_fourCorners_clicked);
+		connect(gamma, &QLinearGradientCtrl::pegMove, this, &ImageViewer::gammaChanging);
+		connect(gamma, &QLinearGradientCtrl::pegMoved, this, &ImageViewer::gammaChanged);
+		connect(information, &QLabel::linkActivated, this, &ImageViewer::saveClicked);
+		connect(copyToClipboard, &QLabel::linkActivated, this, &ImageViewer::copyStackedImage);
 	}
 
 	/* ------------------------------------------------------------------- */


### PR DESCRIPTION
Refactoring runtime Qt connections (SIGNAL/SLOT macros) to compile-time ones.
That way, the compiler checks for the presence of signal and slot functions.
It is safer, and tools used for static analysis are able to do their work, like "find references" functions in most IDEs.