### PR TITLE
Increase read size to fix jpeg files detection

### DIFF
--- a/DeepSkyStackerKernel/BitmapExt.cpp
+++ b/DeepSkyStackerKernel/BitmapExt.cpp
@@ -857,10 +857,10 @@ bool GetPictureInfo(const fs::path& path, CBitmapInfo& BitmapInfo)
 			if (file.isOpen())
 			{
 				//
-				// Read the first 64K of the file into a buffer
+				// Read the first 128K of the file into a buffer
 				//
-				const QByteArray data{ file.peek(65536LL) };
-				const std::string dataString{ data.constData(), 65536ULL };
+				const QByteArray data{ file.peek(131072LL) };
+				const std::string dataString{ data.constData(), 131072ULL };
 				std::istringstream f (dataString);
 				if (isJpeg)
 				{


### PR DESCRIPTION
Current DSS version fails to detect jpeg files created with my phone camera, so I can't add them to the project. The same files work in older 4.x version. This patch fixes the issue for me.

Btw. thanks for making it working on linux. I had to make some modifications to compile it because it coudn't find some libraries but it works after some fixes :)