### PR TITLE
UPDATE: Replace "Time" with "time" to match the rest of the code

### DIFF
--- a/DeepSkyStacker/i18n/DeepSkyStacker_ca.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_ca.ts
@@ -1046,7 +1046,7 @@ Ctrl+4 per canviar el mode de 4 cantonades</translation>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>Temps restant: Desconegut</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_cs.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_cs.ts
@@ -1052,7 +1052,7 @@ Ctrl+4 přepne režim 4 rohů</translation>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>Odhadovaný zbývající čas: Neznámý</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_de.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_de.ts
@@ -1050,7 +1050,7 @@ Strg+4 zum Umschalten des 4-Ecken-Modus</translation>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>Geschätzte verbleibende Zeit: Unbekannt</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_es.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_es.ts
@@ -1049,7 +1049,7 @@ Ctrl+4 para alternar el modo de 4 esquinas</translation>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>Tiempo restante: Desconocido</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_fr.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_fr.ts
@@ -1051,7 +1051,7 @@ Ctrl + 4 pour basculer en mode 4 coins</translation>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>Temps restant estimé : Inconnu</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_it.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_it.ts
@@ -1051,7 +1051,7 @@ Ctrl+4 per attivare/disattivare la modalità 4 angoli</translation>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>Tempo rimanente stimato: Sconosciuto</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_ja_JP.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_ja_JP.ts
@@ -1028,7 +1028,7 @@ Ctrl+4 to toggle 4-Corners mode</source>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation type="unfinished"></translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_nl.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_nl.ts
@@ -1049,7 +1049,7 @@ afbeelding worden verwerkt</translation>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>Geen informatie beschikbaar</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_pt_BR.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_pt_BR.ts
@@ -1051,7 +1051,7 @@ Ctrl+4 para alternar o modo de 4 cantos</translation>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>Tempo estimado de: Desconhecido</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_ro.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_ro.ts
@@ -2870,7 +2870,7 @@ based on its deviation from the mean
 compared to the standard deviation (%1).</source>
         <comment>IDS_TOOLTIP_AUTOADAPTIVE</comment>
         <translation>&lt;b&gt;Media ponderata&lt;/b&gt; este obtinuta prin
-ponderarea iterativa a fiecarei pixel 
+ponderarea iterativa a fiecarei pixel
 de la abaterea de la medie
 comparativ cu abaterea standard (%1).</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_ro.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_ro.ts
@@ -1051,7 +1051,7 @@ Ctrl+4 pentru a comuta în modul 4-Colțuri</translation>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>Timp rămas estimat: Nedeterminat</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_ru.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_ru.ts
@@ -1052,7 +1052,7 @@ Ctrl+4 для переключения режима 4-х углов</translation
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>Осталось времени: Неизвестно</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_tr.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_tr.ts
@@ -1047,7 +1047,7 @@ veya yakınlaştırmak için fare tekerleğini kullanın
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>Tahmin edilen kalan süre: Bilinmiyor</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_tr.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_tr.ts
@@ -321,7 +321,7 @@ The Bicubic method is used when at least 40 stars areavailable, then the Bisquar
 
 Do you want...</source>
         <translation>Bu görüntü hizalanmamış
-(yıldızlar tespit edilemedi). 
+(yıldızlar tespit edilemedi).
 
 Hangisini yapmak istersiniz...</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_zh_CN.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_zh_CN.ts
@@ -1044,7 +1044,7 @@ Ctrl+4 切換四角模式</translation>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>预估剩余时间: 未知</translation>
     </message>

--- a/DeepSkyStacker/i18n/DeepSkyStacker_zh_TW.ts
+++ b/DeepSkyStacker/i18n/DeepSkyStacker_zh_TW.ts
@@ -1044,7 +1044,7 @@ Ctrl+4 切換四角模式</translation>
     </message>
     <message>
         <location filename="../oldprogressdlg.cpp" line="239"/>
-        <source>Estimated remaining Time: Unknown</source>
+        <source>Estimated remaining time: Unknown</source>
         <comment>IDS_ESTIMATEDUNKNOWN</comment>
         <translation>預計剩餘時間: 不明</translation>
     </message>

--- a/DeepSkyStacker/oldprogressdlg.cpp
+++ b/DeepSkyStacker/oldprogressdlg.cpp
@@ -137,7 +137,7 @@ void OldProgressDlg::setItemVisibility(bool bSet1, bool bSet2)
 {
 	ui->ProcessText1->setVisible(bSet1);
 	ui->ProgressBar1->setVisible(bSet1);
-	
+
 	ui->ProcessText2->setVisible(bSet2);
 	ui->ProgressBar2->setVisible(bSet2);
 }

--- a/DeepSkyStacker/oldprogressdlg.cpp
+++ b/DeepSkyStacker/oldprogressdlg.cpp
@@ -236,7 +236,7 @@ void OldProgressDlg::applyProgress1(int lAchieved)
 	}
 	else
 	{
-		const QString qStrText = tr("Estimated remaining Time: Unknown",
+		const QString qStrText = tr("Estimated remaining time: Unknown",
 			"IDS_ESTIMATEDUNKNOWN");
 		setTimeRemaining(qStrText);
 	};

--- a/DeepSkyStacker/progressdlg.cpp
+++ b/DeepSkyStacker/progressdlg.cpp
@@ -294,7 +294,7 @@ void ProgressDlg::applyProgress1(int lAchieved)
 	}
 	else
 	{
-		const QString qStrText = tr("Estimated remaining Time: Unknown",
+		const QString qStrText = tr("Estimated remaining time: Unknown",
 			"IDS_ESTIMATEDUNKNOWN");
 		setTimeRemaining(qStrText);
 	};

--- a/DeepSkyStacker/progressdlg.cpp
+++ b/DeepSkyStacker/progressdlg.cpp
@@ -199,7 +199,7 @@ void ProgressDlg::setItemVisibility(bool bSet1, bool bSet2)
 {
 	ui->ProcessText1->setVisible(bSet1);
 	ui->ProgressBar1->setVisible(bSet1);
-	
+
 	ui->ProcessText2->setVisible(bSet2);
 	ui->ProgressBar2->setVisible(bSet2);
 }


### PR DESCRIPTION
Without this change, it rapidly changes between
"Estimated remaining Time"
and
"Estimated remaining time"
when stacking, which can be very annoying.