### PR TITLE
update the constraints for shadows and midtones

### DIFF
--- a/DeepSkyStacker/QMTFSlider.cpp
+++ b/DeepSkyStacker/QMTFSlider.cpp
@@ -54,14 +54,14 @@ namespace DSS
 
 	void QMTFSlider::setShadows(double val)
 	{
-		m_Shadows = std::clamp(val, 0.0, m_Midtones);
+		m_Shadows = std::clamp(val, 0.0, m_Highlights);
 		update();
 		emit shadowsChanged(m_Shadows);
 	}
 
 	void QMTFSlider::setMidtones(double val)
 	{
-		m_Midtones = std::clamp(val, m_Shadows, m_Highlights);
+		m_Midtones = std::clamp(val, 0.0, m_Highlights);
 		update();
 		emit midtonesChanged(m_Midtones);
 	}
@@ -218,7 +218,7 @@ namespace DSS
 
 			if (m_ActiveHandle == ActiveHandle::Shadows)
 			{
-				val = std::clamp(val, 0.0, m_Midtones); // Cannot pass midtones
+				val = std::clamp(val, 0.0, m_Highlights);
 				m_Shadows = val;
 			}
 			else if (m_ActiveHandle == ActiveHandle::Highlights)
@@ -228,7 +228,7 @@ namespace DSS
 			}
 			else if (m_ActiveHandle == ActiveHandle::Midtones)
 			{
-				val = std::clamp(val, m_Shadows, m_Highlights);
+				val = std::clamp(val, 0.0, m_Highlights);
 				m_Midtones = val;
 			}
 


### PR DESCRIPTION
Supplementary to @perdrix52's commit "_Allow MTF shadow value to be greater than midtone value_" (6dc6bcc55b530c70c4ff1bb2f13b5ffb1614897a)

Removed constraints that prevented the mid-tone slider from moving below the shadow slider. Both sliders can now be adjusted independently across the full range from 0 to the highlights limit.